### PR TITLE
v2 was a complete and utter failure. reboot v3

### DIFF
--- a/v3/go.mod
+++ b/v3/go.mod
@@ -1,0 +1,8 @@
+module github.com/lestrrat-go/pdebug/v3
+
+go 1.16
+
+require (
+	github.com/lestrrat-go/option v0.0.0-20210103042652-6f1ecfceda35
+	github.com/stretchr/testify v1.6.1
+)

--- a/v3/interface.go
+++ b/v3/interface.go
@@ -1,0 +1,18 @@
+package pdebug
+
+import "time"
+
+type MarkerGuard interface {
+	BindError(*error) MarkerGuard
+	End()
+}
+
+type Clock interface {
+	Now() time.Time
+}
+
+type ClockFunc func() time.Time
+
+func (cf ClockFunc) Now() time.Time {
+	return cf()
+}

--- a/v3/options.go
+++ b/v3/options.go
@@ -1,0 +1,20 @@
+package pdebug
+
+import (
+	"io"
+
+	"github.com/lestrrat-go/option"
+)
+
+type Option = option.Interface
+
+type identClock struct{}
+type identWriter struct{}
+
+func WithClock(v Clock) Option {
+	return option.New(identClock{}, v)
+}
+
+func WithWriter(v io.Writer) Option {
+	return option.New(identWriter{}, v)
+}

--- a/v3/pdebug.go
+++ b/v3/pdebug.go
@@ -1,0 +1,232 @@
+// +build debug0 or debug
+
+package pdebug
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strconv"
+	"sync"
+	"time"
+)
+
+const Enabled = true
+const indentPerLevel = 2
+
+func init() {
+	Trace = true
+}
+
+type state struct {
+	clock  Clock
+	indent int
+	mu     sync.RWMutex
+	out    io.Writer
+	prefix []byte
+}
+
+type mGuard struct {
+	errptr    *error
+	indent    int
+	msgFormat string
+	msgArgs   []interface{}
+	out       io.Writer
+	start     time.Time
+}
+
+var Trace bool
+var st = &state{
+	clock:  ClockFunc(time.Now),
+	out:    os.Stderr,
+	prefix: []byte("|DEBUG|"),
+}
+
+func Configure(options ...Option) {
+	var clock Clock
+	var output io.Writer
+	for _, option := range options {
+		switch option.Ident() {
+		case identClock{}:
+			clock = option.Value().(Clock)
+		case identWriter{}:
+			output = option.Value().(io.Writer)
+		}
+	}
+
+	st.mu.Lock()
+	st.clock = clock
+	st.out = output
+	st.mu.Unlock()
+}
+
+func FuncMarker() MarkerGuard {
+	pc, _, _, ok := runtime.Caller(1)
+	if !ok {
+		panic("pdebug.FuncMarker could not determine the name of caller function")
+	}
+	f := runtime.FuncForPC(pc)
+	return Marker(f.Name())
+}
+
+var mGuardPool = sync.Pool{
+	New: allocMGuard,
+}
+
+func allocMGuard() interface{} {
+	return &mGuard{}
+}
+
+func getMGuard() *mGuard {
+	return mGuardPool.Get().(*mGuard)
+}
+
+func releaseMGuard(mg *mGuard) {
+	mg.indent = 0
+	mg.msgFormat = ""
+	mg.msgArgs = nil
+	mGuardPool.Put(mg)
+}
+
+func Marker(format string, args ...interface{}) MarkerGuard {
+	if !Trace {
+		return nil
+	}
+
+	var clock Clock
+	var indent int
+	var prefix []byte
+	st.mu.RLock()
+	clock = st.clock
+	prefix = st.prefix
+	indent = st.indent
+	st.mu.RUnlock()
+
+	mg := getMGuard()
+	mg.indent = indent
+	mg.msgFormat = format
+	mg.msgArgs = args
+
+	if clock := st.clock; clock != nil {
+		mg.start = clock.Now()
+	}
+
+	var buf []byte
+	formatMarkerMessage(&buf, "START "+mg.msgFormat, mg.msgArgs, prefix, nil, clock, mg.indent)
+
+	st.mu.Lock()
+	st.out.Write(buf)
+	st.indent += indentPerLevel
+	st.mu.Unlock()
+	return mg
+}
+
+func (mg *mGuard) BindError(err *error) MarkerGuard {
+	if !Trace {
+		return nil
+	}
+
+	mg.errptr = err
+	return mg
+}
+
+func (mg *mGuard) End() {
+	if !Trace {
+		return
+	}
+
+	var clock Clock
+	var prefix []byte
+	st.mu.Lock()
+	st.indent -= indentPerLevel
+	if st.indent < 0 {
+		st.indent = 0
+	}
+	clock = st.clock
+	prefix = st.prefix
+	st.mu.Unlock()
+
+	var postfix []byte
+
+	if clock != nil || mg.errptr != nil {
+		postfix = append(postfix, '(')
+		if clock != nil {
+			postfix = append(postfix, []byte("elapsed=")...)
+			postfix = append(postfix, []byte(clock.Now().Sub(mg.start).String())...)
+		}
+
+		if errptr := mg.errptr; errptr != nil && *errptr != nil {
+			if clock != nil {
+				postfix = append(postfix, ", "...)
+			}
+			postfix = append(postfix, "error="...)
+			postfix = append(postfix, []byte((*errptr).Error())...)
+		}
+		postfix = append(postfix, ')')
+	}
+
+	var buf []byte
+	formatMarkerMessage(&buf, "END   "+mg.msgFormat, mg.msgArgs, prefix, postfix, clock, mg.indent)
+
+	st.mu.Lock()
+	st.out.Write(buf)
+	st.mu.Unlock()
+
+	releaseMGuard(mg)
+}
+
+func formatMarkerMessage(buf *[]byte, format string, args []interface{}, prefix, postfix []byte, clock Clock, indent int) {
+	// foo\nbar\n should be written as preamble foo\npreamble bar\n
+	var scratch bytes.Buffer
+	fmt.Fprintf(&scratch, format, args...)
+
+	scanner := bufio.NewScanner(&scratch)
+	for scanner.Scan() {
+		appendPreamble(buf, prefix, clock, indent)
+		line := scanner.Bytes()
+		*buf = append(*buf, line...)
+		*buf = append(*buf, postfix...)
+		*buf = append(*buf, '\n')
+	}
+}
+
+func appendPreamble(buf *[]byte, prefix []byte, clock Clock, indent int) {
+	*buf = append(*buf, prefix...)
+
+	*buf = append(*buf, ' ')
+
+	if clock != nil {
+		*buf = append(*buf,
+			[]byte(strconv.FormatFloat(float64(clock.Now().UnixNano())/1000000.0, 'f', 5, 64))...,
+		)
+		*buf = append(*buf, ' ')
+	}
+	for i := 0; i < indent; i++ {
+		*buf = append(*buf, ' ')
+	}
+}
+
+func Printf(format string, args ...interface{}) {
+	if !Trace {
+		return
+	}
+
+	var buf []byte
+	var clock Clock
+	var prefix []byte
+	var indent int
+	st.mu.RLock()
+	clock = st.clock
+	prefix = st.prefix
+	indent = st.indent
+	st.mu.RUnlock()
+
+	formatMarkerMessage(&buf, format, args, prefix, nil, clock, indent)
+
+	st.mu.Lock()
+	st.out.Write(buf)
+	st.mu.Unlock()
+}

--- a/v3/pdebug_off.go
+++ b/v3/pdebug_off.go
@@ -1,0 +1,15 @@
+// +build !debug0,!debug
+
+package pdebug
+
+const Enabled = false
+const Trace = false
+
+type nullMGuard struct {}
+
+func (g nullMGuard) BindError(_ *error) MarkerGuard { return g }
+func (_ nullMGuard) End() {}
+
+func FuncMarker() MarkerGuard { return nullMGuard{} }
+func Marker(_ string, _ ...interface{}) MarkerGuard { return nullMGuard{} }
+func Printf(_ string, _ ...interface{}) {}

--- a/v3/pdebug_off_test.go
+++ b/v3/pdebug_off_test.go
@@ -1,0 +1,23 @@
+// +build !debug0,!debug
+
+package pdebug_test
+
+import (
+	"testing"
+
+	"github.com/lestrrat-go/pdebug/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInterface(t *testing.T) {
+	// If we fail to provide this API, this test should fail to compile
+	_ = pdebug.Marker
+	_ = pdebug.FuncMarker
+	_ = pdebug.Printf
+}
+
+func TestDisabled(t *testing.T) {
+	if !assert.False(t, pdebug.Enabled) {
+		return
+	}
+}

--- a/v3/pdebug_on_test.go
+++ b/v3/pdebug_on_test.go
@@ -1,0 +1,70 @@
+// +build debug0 or debug
+
+package pdebug_test
+
+import (
+	"bytes"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/lestrrat-go/pdebug/v3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMarker(t *testing.T) {
+	fn := func(t *testing.T, wg *sync.WaitGroup) {
+		t.Helper()
+		if wg != nil {
+			defer wg.Done()
+		}
+		var err error
+		g1 := pdebug.FuncMarker().BindError(&err)
+		defer g1.End()
+
+		pdebug.Printf("Hello, World test 1")
+
+		g2 := pdebug.Marker("Test")
+		defer g2.End()
+
+		pdebug.Printf("Hello, World test 2")
+		err = errors.New("test 1 error")
+	}
+
+	var buf bytes.Buffer
+	var now = time.Unix(0, 0)
+	pdebug.Configure(
+		pdebug.WithClock(pdebug.ClockFunc(func() time.Time { return now })),
+		pdebug.WithWriter(&buf),
+	)
+
+	t.Run("Output format", func(t *testing.T) {
+		fn(t, nil)
+		t.Logf("%s", buf.String())
+		if pdebug.Enabled && pdebug.Trace {
+			const expected = `|DEBUG| 0.00000 START github.com/lestrrat-go/pdebug/v3_test.TestMarker.func1
+|DEBUG| 0.00000   Hello, World test 1
+|DEBUG| 0.00000   START Test
+|DEBUG| 0.00000     Hello, World test 2
+|DEBUG| 0.00000   END   Test(elapsed=0s)
+|DEBUG| 0.00000 END   github.com/lestrrat-go/pdebug/v3_test.TestMarker.func1(elapsed=0s, error=test 1 error)
+`
+			if !assert.Equal(t, expected, buf.String()) {
+				return
+			}
+		}
+	})
+	t.Run("Race condition", func(t *testing.T) {
+		// Make sure race conditions don't exist by calling multiple goroutines
+		const gcount = 10
+
+		var wg sync.WaitGroup
+		wg.Add(gcount)
+		for i := 0; i < gcount; i++ {
+			go fn(t, &wg)
+		}
+		wg.Wait()
+	})
+
+}


### PR DESCRIPTION
v3 ditches the idea that we can do things "properly" by using `context.Context`.

What we really wanted was a easy-to-insert debug printing, without needing to think about context.Context or the like.
It's okay if the output is a bit screwed up. It's for debugging. We also want to make sure using `pdebug` doesn't cause problems for tests running with `-race`.